### PR TITLE
feat: add configuration of eks version and ability to use existing VPC for cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "vpc" {
   source                                 = "terraform-aws-modules/vpc/aws"
   version                                = "5.21.0"
   name                                   = var.stack_name
-  create_vpc = var.stack_existing_vpc_config == null
+  create_vpc                             = var.stack_existing_vpc_config == null
   enable_dns_hostnames                   = "true"
   enable_dns_support                     = "true"
   enable_nat_gateway                     = "true"

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "vpc" {
   source                                 = "terraform-aws-modules/vpc/aws"
   version                                = "5.21.0"
   name                                   = var.stack_name
+  create_vpc = var.stack_existing_vpc_config == null
   enable_dns_hostnames                   = "true"
   enable_dns_support                     = "true"
   enable_nat_gateway                     = "true"
@@ -86,7 +87,7 @@ data "aws_region" "current" {}
 
 # https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-vpc-endpoints.html
 resource "aws_vpc_endpoint" "eks_vpc_endpoints" {
-  for_each     = toset(var.vpc_endpoints)
+  for_each     = var.stack_existing_vpc_config == null ? toset(var.vpc_endpoints) : []
   vpc_id       = module.vpc.vpc_id
   service_name = "com.amazonaws.${data.aws_region.current.name}.${each.value}"
   tags         = var.stack_tags
@@ -96,7 +97,7 @@ module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   version         = "20.36.0"
   cluster_name    = var.stack_name
-  cluster_version = "1.31"
+  cluster_version = var.eks_cluster_version
   create          = var.stack_create
   # TODO: resume usage of node security group; see: https://linear.app/pelotech/issue/PEL-97
   create_node_security_group      = false
@@ -104,8 +105,8 @@ module "eks" {
   cluster_endpoint_public_access  = true
   cluster_enabled_log_types       = []
 
-  subnet_ids     = module.vpc.private_subnets
-  vpc_id         = module.vpc.vpc_id
+  vpc_id         = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.vpc_id : module.vpc.vpc_id
+  subnet_ids     = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.subnet_ids : module.vpc.private_subnets
   create_kms_key = true
   enable_irsa    = true
   #    cluster_encryption_config = [{

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "stack_create" {
   default     = true
   description = "should resources be created"
 }
+variable "eks_cluster_version" {
+  type = string
+  default = "1.31"
+  description = "Kubernetes version to set for the cluster"
+}
 variable "stack_tags" {
   type = map(any)
   default = {
@@ -16,6 +21,15 @@ variable "stack_tags" {
   }
   description = "tags to be added to the stack, should at least have Owner and Environment"
 }
+variable "stack_existing_vpc_config" {
+  type = object({
+    vpc_id = string
+    subnet_ids = list(string)
+  })
+  default = null
+  description = "Setting the VPC"
+}
+
 variable "stack_vpc_block" {
   type = object({
     cidr             = string
@@ -143,6 +157,6 @@ variable "s3_csi_driver_bucket_arns" {
 }
 variable "vpc_endpoints" {
   type        = list(string)
-  description = "vpc endpoints within the cluster vpc network"
+  description = "vpc endpoints within the cluster vpc network, note: this only works when using the internal created VPC"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,8 @@ variable "stack_create" {
   description = "should resources be created"
 }
 variable "eks_cluster_version" {
-  type = string
-  default = "1.31"
+  type        = string
+  default     = "1.31"
   description = "Kubernetes version to set for the cluster"
 }
 variable "stack_tags" {
@@ -23,10 +23,10 @@ variable "stack_tags" {
 }
 variable "stack_existing_vpc_config" {
   type = object({
-    vpc_id = string
+    vpc_id     = string
     subnet_ids = list(string)
   })
-  default = null
+  default     = null
   description = "Setting the VPC"
 }
 


### PR DESCRIPTION
1. allow configuration of cluster version to not "force" the cluster version upgrade even if the module is keeping on the latest
2. prep to allow using existing or VPCs created in a sep workflow, it also allows multiple clusters to be deployed in the same VPC