### PR TITLE
feat!: upgrade the cluster to 1.32 as well as set the max pods to 110

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "stack_create" {
 }
 variable "eks_cluster_version" {
   type        = string
-  default     = "1.31"
+  default     = "1.32"
   description = "Kubernetes version to set for the cluster"
 }
 variable "stack_tags" {
@@ -20,6 +20,18 @@ variable "stack_tags" {
     Environment = "prod"
   }
   description = "tags to be added to the stack, should at least have Owner and Environment"
+}
+variable "stack_use_vpc_cni_max_pods" {
+  default = false
+  description = "Set to true if using the vpc cni - otherwise defaults to 110 max pods"
+}
+variable "stack_enable_cluster_kms" {
+  default = true
+  description = "Should secrets be encrypted by kms in the cluster"
+}
+variable "stack_enable_default_eks_managed_node_group" {
+  default = true
+  description = "Ability to disable default node group"
 }
 variable "stack_fck_nat_enabled" {
   type        = bool


### PR DESCRIPTION
Release notes:
* this will force an upgrade on the cluster - you can set the cluster version to keep from upgrade
* stack_use_vpc_cni_max_pods = true (default is false) to have old behavior - this will recreate the nodes with max_pods to 110