### PR TITLE
feat: add node IAM additional policies variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -241,7 +241,8 @@ module "eks" {
           }
         }
       }
-      taints = var.initial_node_taints
+      taints                       = var.initial_node_taints
+      iam_role_additional_policies = var.node_iam_additional_policies
     }
   } : {}
   access_entries = merge(local.admin_access_entries, local.ro_access_entries, local.extra_access_entries)


### PR DESCRIPTION
## Summary
- Adds `node_iam_additional_policies` variable (`map(string)`, default `{}`)
- Wires it into the default EKS managed node group as `iam_role_additional_policies`
- Allows attaching extra IAM policies to node group roles (e.g., KMS decrypt, SSM, custom policies)

## Test plan
- [ ] Run `tofu validate` to verify syntax
- [ ] Run `tofu plan` with default (empty map) — no changes expected
- [ ] Run `tofu plan` with `node_iam_additional_policies = { ssm = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" }` — policy attachment should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)