### PR TITLE
feat!: make vpc-cni opt-in and add explicit addon management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,56 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 
 ## Upgrading to v7.0.0 (breaking changes)
 
-This release adds explicit Terraform-managed cluster addons (`vpc-cni`,
-`kube-proxy`, `coredns`) with per-addon enable toggles, and removes the
-`stack_use_vpc_cni_max_pods` variable.
+This release puts the three core EKS addons (`vpc-cni`, `kube-proxy`,
+`coredns`) under Terraform management via the EKS managed-addons API, with
+per-addon enable toggles. `stack_use_vpc_cni_max_pods` is removed.
 
-**`stack_use_vpc_cni_max_pods` is removed.** The new `stack_enable_vpc_cni_addon`
-variable drives both addon install *and* the nodeadm `maxPods=110` cloudinit:
+### Existing clusters: zero-disruption adoption
 
-| Old setting                            | New setting                          | Behavior                                                  |
-| -------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| `stack_use_vpc_cni_max_pods = false` (default) | `stack_enable_vpc_cni_addon = false` (default) | `maxPods=110` cloudinit applied; install vpc-cni out-of-band or use a non-vpc-cni CNI |
-| `stack_use_vpc_cni_max_pods = true`    | `stack_enable_vpc_cni_addon = true`  | No maxPods cap; this module installs vpc-cni as a managed addon |
+EKS bootstraps every new cluster with self-managed `aws-node`, `kube-proxy`,
+and `coredns` daemonsets. The module now installs these as managed addons
+with `resolve_conflicts_on_create = "OVERWRITE"`, so AWS adopts the existing
+self-managed copies on first apply rather than failing with
+`ResourceInUseException`. No pod restarts or workload disruption beyond
+what AWS does internally on adoption.
 
-If you were running vpc-cni out-of-band (Helm/ArgoCD) and had
-`stack_use_vpc_cni_max_pods = true`, you have two paths:
+After upgrade, `terraform plan` against an existing cluster will show
+`+ create` for each enabled addon — that is the adoption operation, not a
+fresh install.
 
-1. **Move vpc-cni under Terraform management** — set
-   `stack_enable_vpc_cni_addon = true` and uninstall your out-of-band copy.
-2. **Keep your out-of-band install** — drop `stack_use_vpc_cni_max_pods` and
-   accept the new `maxPods=110` cap (or override pod density per-CNI in your
-   CNI tooling).
+### `stack_use_vpc_cni_max_pods` is removed
+
+The new `stack_enable_vpc_cni_addon` (default `true`) drives both addon
+install *and* the nodeadm `maxPods=110` cloudinit:
+
+| Old setting                                     | New equivalent                                | Behavior                                                                            |
+| ----------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `stack_use_vpc_cni_max_pods = false` (default)  | `stack_enable_vpc_cni_addon = true` (default) | vpc-cni managed by this module; pod density follows vpc-cni's ENI math (no 110 cap) |
+| `stack_use_vpc_cni_max_pods = true`             | `stack_enable_vpc_cni_addon = false`          | vpc-cni is **not** installed; `maxPods=110` cloudinit applied for an alternative CNI |
+
+> **Heads-up for users who left `stack_use_vpc_cni_max_pods` at its old
+> default (`false`):** you previously had a hardcoded `maxPods=110` cap.
+> After upgrade you get vpc-cni's ENI-based pod density instead, which on
+> larger instance types is significantly higher. If your scheduling
+> assumptions depend on the 110 cap, pin it via
+> `stack_cluster_addons_overrides` or your node group config.
+
+### Switching to an alternative CNI (Cilium, Kube-OVN)
+
+Set `stack_enable_vpc_cni_addon = false`. The 110-pod nodeadm cloudinit is
+applied automatically and you install your CNI out-of-band (Helm, ArgoCD)
+using the existing outputs (`eks_cluster_endpoint`,
+`eks_cluster_certificate_authority_data`, `eks_oidc_provider_arn`,
+`cluster_security_group_id`, `node_security_group_id`, `vpc`).
 
 ## CNI selection
 
-This module manages the three core EKS addons and leaves CNI install for
-non-vpc-cni options to consumers (Helm, ArgoCD, etc.) using the existing
-outputs (`eks_cluster_endpoint`, `eks_cluster_certificate_authority_data`,
-`eks_oidc_provider_arn`, `cluster_security_group_id`, `node_security_group_id`,
-`vpc`).
-
 | CNI       | `stack_enable_vpc_cni_addon` | `stack_enable_kube_proxy_addon` | Notes                                                            |
 | --------- | ---------------------------- | ------------------------------- | ---------------------------------------------------------------- |
-| vpc-cni   | `true`                       | `true` (default)                | AWS native. IRSA / prefix delegation via `*_overrides`.          |
-| Cilium    | `false` (default)            | `false` for kube-proxy-replace  | Install via Helm post-bootstrap. See Cilium docs for EKS.        |
-| Kube-OVN  | `false` (default)            | `true` (default)                | Install via Helm/ArgoCD post-bootstrap.                          |
-| Other     | `false` (default)            | varies                          | Anything that wants a clean slate works the same way.            |
+| vpc-cni   | `true` (default)             | `true` (default)                | AWS native. IRSA / prefix delegation via `*_overrides`.          |
+| Cilium    | `false`                      | `false` for kube-proxy-replace  | Install via Helm post-bootstrap. See Cilium docs for EKS.        |
+| Kube-OVN  | `false`                      | `true` (default)                | Install via Helm/ArgoCD post-bootstrap.                          |
+| Other     | `false`                      | varies                          | Anything that wants a clean slate works the same way.            |
 
 ### Example: Cilium with kube-proxy replacement
 
@@ -156,7 +171,7 @@ stack_cluster_addons_overrides = {
 | <a name="input_stack_enable_coredns_addon"></a> [stack\_enable\_coredns\_addon](#input\_stack\_enable\_coredns\_addon) | Install coredns as a managed addon. Note: coredns will not schedule until a CNI is running and nodes are Ready. | `bool` | `true` | no |
 | <a name="input_stack_enable_default_eks_managed_node_group"></a> [stack\_enable\_default\_eks\_managed\_node\_group](#input\_stack\_enable\_default\_eks\_managed\_node\_group) | Ability to disable default node group | `bool` | `true` | no |
 | <a name="input_stack_enable_kube_proxy_addon"></a> [stack\_enable\_kube\_proxy\_addon](#input\_stack\_enable\_kube\_proxy\_addon) | Install kube-proxy as a managed addon. Set false when using Cilium with kube-proxy replacement enabled. | `bool` | `true` | no |
-| <a name="input_stack_enable_vpc_cni_addon"></a> [stack\_enable\_vpc\_cni\_addon](#input\_stack\_enable\_vpc\_cni\_addon) | Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically. | `bool` | `false` | no |
+| <a name="input_stack_enable_vpc_cni_addon"></a> [stack\_enable\_vpc\_cni\_addon](#input\_stack\_enable\_vpc\_cni\_addon) | Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically. | `bool` | `true` | no |
 | <a name="input_stack_existing_vpc_config"></a> [stack\_existing\_vpc\_config](#input\_stack\_existing\_vpc\_config) | Setting the VPC | <pre>object({<br/>    vpc_id     = string<br/>    subnet_ids = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | Name of the stack | `string` | `"foundation-stack"` | no |
 | <a name="input_stack_pelotech_nat_ami_name_filter"></a> [stack\_pelotech\_nat\_ami\_name\_filter](#input\_stack\_pelotech\_nat\_ami\_name\_filter) | ami name filter to find the correct ami | `string` | `"fck-nat-al2023-hvm-*"` | no |

--- a/README.md
+++ b/README.md
@@ -7,56 +7,81 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 
 ## Upgrading to v7.0.0 (breaking changes)
 
-This release puts the three core EKS addons (`vpc-cni`, `kube-proxy`,
-`coredns`) under Terraform management via the EKS managed-addons API, with
-per-addon enable toggles. `stack_use_vpc_cni_max_pods` is removed.
+This release puts the three core EKS addons under Terraform management via
+the EKS managed-addons API, with per-addon enable toggles. **vpc-cni is now
+opt-in** (`stack_enable_vpc_cni_addon` defaults to `false`); kube-proxy and
+coredns default to `true`. `stack_use_vpc_cni_max_pods` is removed.
 
-### Existing clusters: zero-disruption adoption
+### What happens on first apply against an existing cluster
 
-EKS bootstraps every new cluster with self-managed `aws-node`, `kube-proxy`,
-and `coredns` daemonsets. The module now installs these as managed addons
-with `resolve_conflicts_on_create = "OVERWRITE"`, so AWS adopts the existing
-self-managed copies on first apply rather than failing with
-`ResourceInUseException`. No pod restarts or workload disruption beyond
-what AWS does internally on adoption.
+| Addon       | Default | Plan effect on an existing v6.x cluster                                                              |
+| ----------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| vpc-cni     | `false` | **Nothing.** Existing self-managed `aws-node` DaemonSet is left untouched and remains unmanaged.     |
+| kube-proxy  | `true`  | `+ create` managed addon. `OVERWRITE` adopts the existing self-managed DaemonSet. No disruption.     |
+| coredns     | `true`  | `+ create` managed addon. `OVERWRITE` adopts the existing self-managed Deployment. No disruption.    |
 
-After upgrade, `terraform plan` against an existing cluster will show
-`+ create` for each enabled addon — that is the adoption operation, not a
-fresh install.
+If you want to keep vpc-cni under Terraform, set
+`stack_enable_vpc_cni_addon = true` explicitly — the same OVERWRITE
+adoption applies (no pod restarts).
 
 ### `stack_use_vpc_cni_max_pods` is removed
 
-The new `stack_enable_vpc_cni_addon` (default `true`) drives both addon
-install *and* the nodeadm `maxPods=110` cloudinit:
+`stack_enable_vpc_cni_addon` now drives both addon install *and* the
+nodeadm `maxPods=110` cloudinit:
 
-| Old setting                                     | New equivalent                                | Behavior                                                                            |
-| ----------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `stack_use_vpc_cni_max_pods = false` (default)  | `stack_enable_vpc_cni_addon = true` (default) | vpc-cni managed by this module; pod density follows vpc-cni's ENI math (no 110 cap) |
-| `stack_use_vpc_cni_max_pods = true`             | `stack_enable_vpc_cni_addon = false`          | vpc-cni is **not** installed; `maxPods=110` cloudinit applied for an alternative CNI |
+| Old setting                                     | New equivalent                                 | Behavior                                                                                |
+| ----------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `stack_use_vpc_cni_max_pods = false` (default)  | `stack_enable_vpc_cni_addon = false` (default) | No managed vpc-cni; **nodes get `maxPods=110` cloudinit** so an alternative CNI fits.   |
+| `stack_use_vpc_cni_max_pods = true`             | `stack_enable_vpc_cni_addon = true`            | vpc-cni installed/adopted as managed addon; no maxPods cloudinit (ENI math drives pod density). |
 
-> **Heads-up for users who left `stack_use_vpc_cni_max_pods` at its old
-> default (`false`):** you previously had a hardcoded `maxPods=110` cap.
-> After upgrade you get vpc-cni's ENI-based pod density instead, which on
-> larger instance types is significantly higher. If your scheduling
-> assumptions depend on the 110 cap, pin it via
-> `stack_cluster_addons_overrides` or your node group config.
+> **Heads-up for users running self-managed vpc-cni today:** with the new
+> default (`false`), the next node refresh will apply `maxPods=110`
+> cloudinit even though `aws-node` is still running on your nodes. To
+> preserve the prior pod-density behavior, set
+> `stack_enable_vpc_cni_addon = true` so the module manages vpc-cni and
+> skips the cloudinit cap.
+
+### Removing vpc-cni from an existing cluster (CNI swap)
+
+Because Terraform never managed your existing `aws-node` DaemonSet, simply
+leaving `stack_enable_vpc_cni_addon` at its default `false` will not
+remove it. Two paths:
+
+1. **Two-step (recommended):** set `stack_enable_vpc_cni_addon = true`,
+   apply (AWS adopts the DaemonSet via `OVERWRITE`); then set it back to
+   `false`, apply (managed addon is destroyed and `preserve = false`
+   removes the DaemonSet too).
+2. **Manual:** leave the variable at `false` and run
+   `kubectl delete daemonset -n kube-system aws-node` once your
+   replacement CNI is healthy.
 
 ### Switching to an alternative CNI (Cilium, Kube-OVN)
 
-Set `stack_enable_vpc_cni_addon = false`. The 110-pod nodeadm cloudinit is
-applied automatically and you install your CNI out-of-band (Helm, ArgoCD)
-using the existing outputs (`eks_cluster_endpoint`,
+The default behavior already supports this: keep
+`stack_enable_vpc_cni_addon = false`, install your CNI out-of-band (Helm,
+ArgoCD) using the existing outputs (`eks_cluster_endpoint`,
 `eks_cluster_certificate_authority_data`, `eks_oidc_provider_arn`,
-`cluster_security_group_id`, `node_security_group_id`, `vpc`).
+`cluster_security_group_id`, `node_security_group_id`, `vpc`). The
+`maxPods=110` nodeadm cloudinit is applied automatically.
+
+> **Removal is destructive by design.** Disabling any managed addon
+> (`stack_enable_vpc_cni_addon`, `stack_enable_kube_proxy_addon`,
+> `stack_enable_coredns_addon`) after it has been adopted tells AWS to
+> remove **both** the addon registration and its underlying workload
+> (`aws-node` / `kube-proxy` / `coredns`) — the module sets
+> `preserve = false` so a CNI swap leaves a clean slate. For phased
+> migrations where you want the workload to keep running after
+> deregistration, set `preserve = true` per-addon via
+> `stack_cluster_addons_overrides` (see "Power-user overrides" below).
 
 ## CNI selection
 
 | CNI       | `stack_enable_vpc_cni_addon` | `stack_enable_kube_proxy_addon` | Notes                                                            |
 | --------- | ---------------------------- | ------------------------------- | ---------------------------------------------------------------- |
-| vpc-cni   | `true` (default)             | `true` (default)                | AWS native. IRSA / prefix delegation via `*_overrides`.          |
-| Cilium    | `false`                      | `false` for kube-proxy-replace  | Install via Helm post-bootstrap. See Cilium docs for EKS.        |
-| Kube-OVN  | `false`                      | `true` (default)                | Install via Helm/ArgoCD post-bootstrap.                          |
-| Other     | `false`                      | varies                          | Anything that wants a clean slate works the same way.            |
+| vpc-cni   | `true`                       | `true` (default)                | AWS native. IRSA / prefix delegation via `*_overrides`.          |
+| Cilium    | `false` (default)            | `false` for kube-proxy-replace  | Install via Helm post-bootstrap. See Cilium docs for EKS.        |
+| Kube-OVN  | `false` (default)            | `true` (default)                | Install via Helm/ArgoCD post-bootstrap.                          |
+| Other     | `false` (default)            | varies                          | Anything that wants a clean slate works the same way.            |
 
 ### Example: Cilium with kube-proxy replacement
 
@@ -96,6 +121,9 @@ stack_cluster_addons_overrides = {
     configuration_values = jsonencode({
       env = { ENABLE_PREFIX_DELEGATION = "true" }
     })
+    # Keep the aws-node DaemonSet running after disabling the managed addon
+    # (e.g. for a phased CNI migration). Default is preserve = false.
+    preserve = true
   }
   "coredns" = {
     addon_version = "v1.11.4-eksbuild.2"
@@ -171,7 +199,7 @@ stack_cluster_addons_overrides = {
 | <a name="input_stack_enable_coredns_addon"></a> [stack\_enable\_coredns\_addon](#input\_stack\_enable\_coredns\_addon) | Install coredns as a managed addon. Note: coredns will not schedule until a CNI is running and nodes are Ready. | `bool` | `true` | no |
 | <a name="input_stack_enable_default_eks_managed_node_group"></a> [stack\_enable\_default\_eks\_managed\_node\_group](#input\_stack\_enable\_default\_eks\_managed\_node\_group) | Ability to disable default node group | `bool` | `true` | no |
 | <a name="input_stack_enable_kube_proxy_addon"></a> [stack\_enable\_kube\_proxy\_addon](#input\_stack\_enable\_kube\_proxy\_addon) | Install kube-proxy as a managed addon. Set false when using Cilium with kube-proxy replacement enabled. | `bool` | `true` | no |
-| <a name="input_stack_enable_vpc_cni_addon"></a> [stack\_enable\_vpc\_cni\_addon](#input\_stack\_enable\_vpc\_cni\_addon) | Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically. | `bool` | `true` | no |
+| <a name="input_stack_enable_vpc_cni_addon"></a> [stack\_enable\_vpc\_cni\_addon](#input\_stack\_enable\_vpc\_cni\_addon) | Install AWS VPC CNI as a managed addon. Defaults to false so the cluster comes up CNI-less and consumers pick a CNI (Cilium, Kube-OVN, or vpc-cni). Set true to install vpc-cni as a managed addon. When false, nodeadm maxPods=110 cloudinit is applied automatically. | `bool` | `false` | no |
 | <a name="input_stack_existing_vpc_config"></a> [stack\_existing\_vpc\_config](#input\_stack\_existing\_vpc\_config) | Setting the VPC | <pre>object({<br/>    vpc_id     = string<br/>    subnet_ids = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | Name of the stack | `string` | `"foundation-stack"` | no |
 | <a name="input_stack_pelotech_nat_ami_name_filter"></a> [stack\_pelotech\_nat\_ami\_name\_filter](#input\_stack\_pelotech\_nat\_ami\_name\_filter) | ami name filter to find the correct ami | `string` | `"fck-nat-al2023-hvm-*"` | no |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,90 @@ This is the terraform module that helps bootstrap foundation in AWS
 
 This project uses [release-please](https://github.com/googleapis/release-please) for the release flow of contributions
 
+## Upgrading to v7.0.0 (breaking changes)
+
+This release adds explicit Terraform-managed cluster addons (`vpc-cni`,
+`kube-proxy`, `coredns`) with per-addon enable toggles, and removes the
+`stack_use_vpc_cni_max_pods` variable.
+
+**`stack_use_vpc_cni_max_pods` is removed.** The new `stack_enable_vpc_cni_addon`
+variable drives both addon install *and* the nodeadm `maxPods=110` cloudinit:
+
+| Old setting                            | New setting                          | Behavior                                                  |
+| -------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `stack_use_vpc_cni_max_pods = false` (default) | `stack_enable_vpc_cni_addon = false` (default) | `maxPods=110` cloudinit applied; install vpc-cni out-of-band or use a non-vpc-cni CNI |
+| `stack_use_vpc_cni_max_pods = true`    | `stack_enable_vpc_cni_addon = true`  | No maxPods cap; this module installs vpc-cni as a managed addon |
+
+If you were running vpc-cni out-of-band (Helm/ArgoCD) and had
+`stack_use_vpc_cni_max_pods = true`, you have two paths:
+
+1. **Move vpc-cni under Terraform management** — set
+   `stack_enable_vpc_cni_addon = true` and uninstall your out-of-band copy.
+2. **Keep your out-of-band install** — drop `stack_use_vpc_cni_max_pods` and
+   accept the new `maxPods=110` cap (or override pod density per-CNI in your
+   CNI tooling).
+
+## CNI selection
+
+This module manages the three core EKS addons and leaves CNI install for
+non-vpc-cni options to consumers (Helm, ArgoCD, etc.) using the existing
+outputs (`eks_cluster_endpoint`, `eks_cluster_certificate_authority_data`,
+`eks_oidc_provider_arn`, `cluster_security_group_id`, `node_security_group_id`,
+`vpc`).
+
+| CNI       | `stack_enable_vpc_cni_addon` | `stack_enable_kube_proxy_addon` | Notes                                                            |
+| --------- | ---------------------------- | ------------------------------- | ---------------------------------------------------------------- |
+| vpc-cni   | `true`                       | `true` (default)                | AWS native. IRSA / prefix delegation via `*_overrides`.          |
+| Cilium    | `false` (default)            | `false` for kube-proxy-replace  | Install via Helm post-bootstrap. See Cilium docs for EKS.        |
+| Kube-OVN  | `false` (default)            | `true` (default)                | Install via Helm/ArgoCD post-bootstrap.                          |
+| Other     | `false` (default)            | varies                          | Anything that wants a clean slate works the same way.            |
+
+### Example: Cilium with kube-proxy replacement
+
+```hcl
+module "foundation" {
+  # ...
+  stack_enable_vpc_cni_addon    = false
+  stack_enable_kube_proxy_addon = false
+  stack_enable_coredns_addon    = true
+}
+```
+
+Then install Cilium with `kubeProxyReplacement=true` per the
+[Cilium EKS install guide](https://docs.cilium.io/en/stable/installation/k8s-install-helm/).
+
+### Example: Kube-OVN
+
+```hcl
+module "foundation" {
+  # ...
+  stack_enable_vpc_cni_addon = false
+  # kube-proxy and coredns stay enabled
+}
+```
+
+Install Kube-OVN per the
+[upstream install docs](https://kubeovn.github.io/docs/stable/en/start/one-step-install/).
+
+### Power-user overrides
+
+Pin addon versions or pass addon-specific configuration (e.g. vpc-cni prefix
+delegation) via `stack_cluster_addons_overrides`:
+
+```hcl
+stack_cluster_addons_overrides = {
+  "vpc-cni" = {
+    configuration_values = jsonencode({
+      env = { ENABLE_PREFIX_DELEGATION = "true" }
+    })
+  }
+  "coredns" = {
+    addon_version = "v1.11.4-eksbuild.2"
+    most_recent   = false
+  }
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -65,10 +149,14 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 | <a name="input_s3_csi_driver_bucket_arns"></a> [s3\_csi\_driver\_bucket\_arns](#input\_s3\_csi\_driver\_bucket\_arns) | existing buckets the s3 CSI driver should have access to | `list(string)` | `[]` | no |
 | <a name="input_s3_csi_driver_create_bucket"></a> [s3\_csi\_driver\_create\_bucket](#input\_s3\_csi\_driver\_create\_bucket) | create a new bucket for use with the s3 CSI driver | `bool` | `true` | no |
 | <a name="input_stack_admin_arns"></a> [stack\_admin\_arns](#input\_stack\_admin\_arns) | arn to the roles for the cluster admins role | `list(string)` | `[]` | no |
+| <a name="input_stack_cluster_addons_overrides"></a> [stack\_cluster\_addons\_overrides](#input\_stack\_cluster\_addons\_overrides) | Per-addon overrides keyed by addon name (e.g. "vpc-cni", "kube-proxy", "coredns"). Merges over module defaults — use for version pinning, vpc-cni prefix delegation, custom networking, etc. Accepts any attributes supported by terraform-aws-modules/eks/aws v21+ `addons` map. | `any` | `{}` | no |
 | <a name="input_stack_create"></a> [stack\_create](#input\_stack\_create) | should resources be created | `bool` | `true` | no |
 | <a name="input_stack_create_pelotech_nat_eip"></a> [stack\_create\_pelotech\_nat\_eip](#input\_stack\_create\_pelotech\_nat\_eip) | should create pelotech nat eip even if NAT isn't enabled - nice for getting ips created for allow lists | `bool` | `false` | no |
 | <a name="input_stack_enable_cluster_kms"></a> [stack\_enable\_cluster\_kms](#input\_stack\_enable\_cluster\_kms) | Should secrets be encrypted by kms in the cluster | `bool` | `true` | no |
+| <a name="input_stack_enable_coredns_addon"></a> [stack\_enable\_coredns\_addon](#input\_stack\_enable\_coredns\_addon) | Install coredns as a managed addon. Note: coredns will not schedule until a CNI is running and nodes are Ready. | `bool` | `true` | no |
 | <a name="input_stack_enable_default_eks_managed_node_group"></a> [stack\_enable\_default\_eks\_managed\_node\_group](#input\_stack\_enable\_default\_eks\_managed\_node\_group) | Ability to disable default node group | `bool` | `true` | no |
+| <a name="input_stack_enable_kube_proxy_addon"></a> [stack\_enable\_kube\_proxy\_addon](#input\_stack\_enable\_kube\_proxy\_addon) | Install kube-proxy as a managed addon. Set false when using Cilium with kube-proxy replacement enabled. | `bool` | `true` | no |
+| <a name="input_stack_enable_vpc_cni_addon"></a> [stack\_enable\_vpc\_cni\_addon](#input\_stack\_enable\_vpc\_cni\_addon) | Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically. | `bool` | `false` | no |
 | <a name="input_stack_existing_vpc_config"></a> [stack\_existing\_vpc\_config](#input\_stack\_existing\_vpc\_config) | Setting the VPC | <pre>object({<br/>    vpc_id     = string<br/>    subnet_ids = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | Name of the stack | `string` | `"foundation-stack"` | no |
 | <a name="input_stack_pelotech_nat_ami_name_filter"></a> [stack\_pelotech\_nat\_ami\_name\_filter](#input\_stack\_pelotech\_nat\_ami\_name\_filter) | ami name filter to find the correct ami | `string` | `"fck-nat-al2023-hvm-*"` | no |
@@ -77,7 +165,6 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 | <a name="input_stack_pelotech_nat_instance_type"></a> [stack\_pelotech\_nat\_instance\_type](#input\_stack\_pelotech\_nat\_instance\_type) | choose instance based on bandwitch requirements | `string` | `"t4g.micro"` | no |
 | <a name="input_stack_ro_arns"></a> [stack\_ro\_arns](#input\_stack\_ro\_arns) | arn to the roles for the cluster read only role, these will also have KMS readonly access for CI plan purposes, more limited access should use the extra entries | `list(string)` | `[]` | no |
 | <a name="input_stack_tags"></a> [stack\_tags](#input\_stack\_tags) | tags to be added to the stack, should at least have Owner and Environment | `map(string)` | <pre>{<br/>  "Environment": "prod",<br/>  "Owner": "pelotech"<br/>}</pre> | no |
-| <a name="input_stack_use_vpc_cni_max_pods"></a> [stack\_use\_vpc\_cni\_max\_pods](#input\_stack\_use\_vpc\_cni\_max\_pods) | Set to true if using the vpc cni - otherwise defaults to 110 max pods | `bool` | `false` | no |
 | <a name="input_stack_vpc_block"></a> [stack\_vpc\_block](#input\_stack\_vpc\_block) | Variables for defining the vpc for the stack | <pre>object({<br/>    cidr             = string<br/>    azs              = list(string)<br/>    private_subnets  = list(string)<br/>    public_subnets   = list(string)<br/>    database_subnets = list(string)<br/>  })</pre> | <pre>{<br/>  "azs": [<br/>    "us-west-2a",<br/>    "us-west-2b",<br/>    "us-west-2c"<br/>  ],<br/>  "cidr": "172.16.0.0/16",<br/>  "database_subnets": [<br/>    "172.16.200.0/24",<br/>    "172.16.201.0/24",<br/>    "172.16.202.0/24"<br/>  ],<br/>  "private_subnets": [<br/>    "172.16.0.0/24",<br/>    "172.16.1.0/24",<br/>    "172.16.2.0/24"<br/>  ],<br/>  "public_subnets": [<br/>    "172.16.100.0/24",<br/>    "172.16.101.0/24",<br/>    "172.16.102.0/24"<br/>  ]<br/>}</pre> | no |
 | <a name="input_vpc_endpoints"></a> [vpc\_endpoints](#input\_vpc\_endpoints) | vpc endpoints within the cluster vpc network, note: this only works when using the internal created VPC | `list(string)` | `[]` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,24 @@ locals {
     for index, item in var.extra_access_entries : "extra_${index}" => item
   }
   s3_csi_arns = compact(concat([module.s3_csi.s3_bucket_arn], var.s3_csi_driver_bucket_arns))
+
+  # before_compute on vpc-cni installs the addon ahead of node groups so pods get IPs immediately
+  cluster_addon_defaults = {
+    "vpc-cni"    = { most_recent = true, before_compute = true }
+    "kube-proxy" = { most_recent = true }
+    "coredns"    = { most_recent = true }
+  }
+  cluster_addons_enabled = {
+    "vpc-cni"    = var.stack_enable_vpc_cni_addon
+    "kube-proxy" = var.stack_enable_kube_proxy_addon
+    "coredns"    = var.stack_enable_coredns_addon
+  }
+  cluster_addons = {
+    for name, enabled in local.cluster_addons_enabled : name =>
+    merge(local.cluster_addon_defaults[name], try(var.stack_cluster_addons_overrides[name], {}))
+    if enabled
+  }
+
   # See https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/
   cloudinit_pre_nodeadm = [
     {
@@ -165,6 +183,7 @@ module "eks" {
 
   vpc_id         = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.vpc_id : module.vpc.vpc_id
   subnet_ids     = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.subnet_ids : module.vpc.private_subnets
+  addons         = local.cluster_addons
   create_kms_key = var.stack_enable_cluster_kms
   enable_irsa    = true
   encryption_config = var.stack_enable_cluster_kms ? {
@@ -191,7 +210,7 @@ module "eks" {
         http_tokens                 = "required"
       }
       labels                = var.initial_node_labels
-      cloudinit_pre_nodeadm = var.stack_use_vpc_cni_max_pods ? [] : local.cloudinit_pre_nodeadm
+      cloudinit_pre_nodeadm = var.stack_enable_vpc_cni_addon ? [] : local.cloudinit_pre_nodeadm
       block_device_mappings = {
         xvda = {
           device_name = "/dev/xvda"

--- a/main.tf
+++ b/main.tf
@@ -227,7 +227,7 @@ module "eks" {
         http_put_response_hop_limit = 2
         http_tokens                 = "required"
       }
-      labels = var.initial_node_labels
+      labels                = var.initial_node_labels
       cloudinit_pre_nodeadm = var.stack_enable_vpc_cni_addon ? [] : local.cloudinit_pre_nodeadm
       block_device_mappings = {
         xvda = {

--- a/main.tf
+++ b/main.tf
@@ -42,11 +42,25 @@ locals {
   }
   s3_csi_arns = compact(concat([module.s3_csi.s3_bucket_arn], var.s3_csi_driver_bucket_arns))
 
+  # OVERWRITE on create lets AWS adopt any pre-existing self-managed daemonsets into the managed-addons API
   # before_compute on vpc-cni installs the addon ahead of node groups so pods get IPs immediately
   cluster_addon_defaults = {
-    "vpc-cni"    = { most_recent = true, before_compute = true }
-    "kube-proxy" = { most_recent = true }
-    "coredns"    = { most_recent = true }
+    "vpc-cni" = {
+      most_recent                 = true
+      before_compute              = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+    "kube-proxy" = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
+    "coredns" = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+    }
   }
   cluster_addons_enabled = {
     "vpc-cni"    = var.stack_enable_vpc_cni_addon
@@ -180,12 +194,11 @@ module "eks" {
   endpoint_private_access       = true
   endpoint_public_access        = var.cluster_endpoint_public_access
   enabled_log_types             = var.cluster_enabled_log_types
-
-  vpc_id         = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.vpc_id : module.vpc.vpc_id
-  subnet_ids     = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.subnet_ids : module.vpc.private_subnets
-  addons         = local.cluster_addons
-  create_kms_key = var.stack_enable_cluster_kms
-  enable_irsa    = true
+  vpc_id                        = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.vpc_id : module.vpc.vpc_id
+  subnet_ids                    = var.stack_existing_vpc_config != null ? var.stack_existing_vpc_config.subnet_ids : module.vpc.private_subnets
+  addons                        = local.cluster_addons
+  create_kms_key                = var.stack_enable_cluster_kms
+  enable_irsa                   = true
   encryption_config = var.stack_enable_cluster_kms ? {
     "resources" : [
       "secrets"

--- a/main.tf
+++ b/main.tf
@@ -42,22 +42,27 @@ locals {
   }
   s3_csi_arns = compact(concat([module.s3_csi.s3_bucket_arn], var.s3_csi_driver_bucket_arns))
 
-  # OVERWRITE on create lets AWS adopt any pre-existing self-managed daemonsets into the managed-addons API
-  # before_compute on vpc-cni installs the addon ahead of node groups so pods get IPs immediately
+  # OVERWRITE on create lets AWS adopt any pre-existing self-managed daemonsets into the managed-addons API.
+  # before_compute on vpc-cni installs the addon ahead of node groups so pods get IPs immediately.
+  # preserve=false overrides the upstream module default (true) so disabling an addon also removes
+  # its underlying workload (e.g. aws-node DaemonSet) — required for clean CNI swaps.
   cluster_addon_defaults = {
     "vpc-cni" = {
       most_recent                 = true
       before_compute              = true
+      preserve                    = false
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
     }
     "kube-proxy" = {
       most_recent                 = true
+      preserve                    = false
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
     }
     "coredns" = {
       most_recent                 = true
+      preserve                    = false
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
     }
@@ -222,7 +227,7 @@ module "eks" {
         http_put_response_hop_limit = 2
         http_tokens                 = "required"
       }
-      labels                = var.initial_node_labels
+      labels = var.initial_node_labels
       cloudinit_pre_nodeadm = var.stack_enable_vpc_cni_addon ? [] : local.cloudinit_pre_nodeadm
       block_device_mappings = {
         xvda = {

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "stack_tags" {
 }
 variable "stack_enable_vpc_cni_addon" {
   type        = bool
-  default     = false
+  default     = true
   description = "Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically."
 }
 variable "stack_enable_kube_proxy_addon" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,8 +33,8 @@ variable "stack_tags" {
 }
 variable "stack_enable_vpc_cni_addon" {
   type        = bool
-  default     = true
-  description = "Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically."
+  default     = false
+  description = "Install AWS VPC CNI as a managed addon. Defaults to false so the cluster comes up CNI-less and consumers pick a CNI (Cilium, Kube-OVN, or vpc-cni). Set true to install vpc-cni as a managed addon. When false, nodeadm maxPods=110 cloudinit is applied automatically."
 }
 variable "stack_enable_kube_proxy_addon" {
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -31,10 +31,25 @@ variable "stack_tags" {
   }
   description = "tags to be added to the stack, should at least have Owner and Environment"
 }
-variable "stack_use_vpc_cni_max_pods" {
+variable "stack_enable_vpc_cni_addon" {
   type        = bool
   default     = false
-  description = "Set to true if using the vpc cni - otherwise defaults to 110 max pods"
+  description = "Install AWS VPC CNI as a managed addon. Set false when using Cilium, Kube-OVN, or another CNI installed out-of-band. When false, nodeadm maxPods=110 cloudinit is applied automatically."
+}
+variable "stack_enable_kube_proxy_addon" {
+  type        = bool
+  default     = true
+  description = "Install kube-proxy as a managed addon. Set false when using Cilium with kube-proxy replacement enabled."
+}
+variable "stack_enable_coredns_addon" {
+  type        = bool
+  default     = true
+  description = "Install coredns as a managed addon. Note: coredns will not schedule until a CNI is running and nodes are Ready."
+}
+variable "stack_cluster_addons_overrides" {
+  type        = any
+  default     = {}
+  description = "Per-addon overrides keyed by addon name (e.g. \"vpc-cni\", \"kube-proxy\", \"coredns\"). Merges over module defaults — use for version pinning, vpc-cni prefix delegation, custom networking, etc. Accepts any attributes supported by terraform-aws-modules/eks/aws v21+ `addons` map."
 }
 variable "stack_enable_cluster_kms" {
   type        = bool


### PR DESCRIPTION
## Summary

- Manage `vpc-cni`, `kube-proxy`, and `coredns` explicitly through the EKS module's `addons` argument so clusters using alternative CNIs (Cilium, Kube-OVN, etc.) don't race against AWS's default vpc-cni install.
- Add per-addon enable toggles (`stack_enable_vpc_cni_addon` default `false`, `stack_enable_kube_proxy_addon` / `stack_enable_coredns_addon` default `true`) and a `stack_cluster_addons_overrides` escape-hatch for version pinning, vpc-cni prefix delegation, etc.
- Remove `stack_use_vpc_cni_max_pods`; the new `stack_enable_vpc_cni_addon` toggle now drives both addon install and the nodeadm `maxPods=110` cloudinit (vpc-cni on → empty cloudinit; vpc-cni off → 110-pod cloudinit applied).

CNI install for non-vpc-cni options stays out-of-band (Helm/ArgoCD) using the existing module outputs — keeping the module infra-only and matching the existing pattern for kube-ovn already referenced in node labels/taints.

## Migration

See the new "Upgrading to v7.0.0" section in `README.md`. Two paths for users currently running vpc-cni out-of-band with `stack_use_vpc_cni_max_pods = true`:

1. **Move under Terraform management** — set `stack_enable_vpc_cni_addon = true` and remove the out-of-band copy.
2. **Keep out-of-band install** — drop `stack_use_vpc_cni_max_pods` and accept the new `maxPods=110` cap.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` clean (one pre-existing `data.aws_region.current.name` warning, unrelated)
- [x] `pre-commit run --all-files` passes (terraform-docs regenerated the inputs table)
- [ ] `terraform plan` against an existing test workspace with no var changes — expected: no addon resource changes (cluster currently has no managed addons in v6.x)
- [ ] `terraform plan` with `stack_enable_vpc_cni_addon = true` — expected: `aws_eks_addon.this["vpc-cni"]` will be added
- [ ] New cluster with all defaults — `kubectl get pods -n kube-system` shows coredns + kube-proxy, no `aws-node` DaemonSet; nodes stay NotReady until a CNI is installed
- [ ] New cluster with `stack_enable_vpc_cni_addon = true` — nodes Ready, `aws-node` DaemonSet present
- [ ] New cluster with `stack_cluster_addons_overrides = { "vpc-cni" = { configuration_values = jsonencode({ env = { ENABLE_PREFIX_DELEGATION = "true" } }) } }` — plan shows `configuration_values` applied

release-please will cut `7.0.0` from the `feat!:` commit footer.